### PR TITLE
Add the ability to add paths on commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,63 +37,152 @@ The basic stack.yml file must have this format
 
 ```yaml
 stack:
-    commands:
+  commands:
 ```
 
 All the commands you define will be under the `commands:` node
 
-Here is an example of a more complex `stack.yml` file with examples of different ways you can configure your commands.
+A command can be in several forms depending on your needs.
 
-**Example**
+**The most basic**
 
 ```yaml
 stack:
   commands:
-    init:
-      description: Run to setup the complete stack
+    mydir: echo $(pwd)
+```
+
+**With multiple commands**
+
+```yaml
+stack:
+  commands:
+    mydir: 
+      - echo This is my current directory
+      - echo $(pwd)
+```
+
+**With a description**
+
+```yaml
+stack:
+  commands:
+    mydir: 
+      description: This will print out my current directory
       commands:
-        - git clone git@github.com:username/repo.git repos/my-app1
-        - cd repos/my-app1 && npm install
-        - git clone git@github.com:username/repo.git repos/my-app2
-        - cd repos/my-app2 && composer install
-        - export COMPOSE_INTERACTIVE_NO_CLI=1
-        - docker-compose up -d
-        - docker-compose exec api php artisan migrate
-        - docker-compose down
-    up:
-      description: Spin up my stack
-      commmands: docker-compose up -d
-    down: docker-compose down
-    migrate:
-      description: Migrate database. NOTE - Stack must be running
-      commands: export COMPOSE_INTERACTIVE_NO_CLI=1 && docker-compose exec my-app2 php artisan migrate
+        - echo $(pwd)
+        - echo There it is
+```
+
+**With a working directory**
+
+You can specify the working directory relative to where the command is being ran
+
+```yaml
+stack:
+  commands:
+    mydir: 
+      description: This will print out my current directory
+      path: test/path
+      commands:
+        - echo 'this is file1' >> file1.txt
+```
+
+If the directory `test/path` exists the above command will create the file `test/path/file1.txt
+
+**With multiple commands with multiple working directories**
+
+Not the command keys `0`, `1`, and `2`. These are arbitrary and can be what ever you want them to be as long as they are unique to this list of commands (not unique for the entire stack.yml file)
+
+```yaml
+stack:
+  commands:
+    mydir: 
+      description: This will print out my current directory
+      commands:
+        0:
+          commands: mkdir newdir
+        1:
+          path: newdir
+          commands: 
+            - echo 'this is file1' >> file1.txt
+            - mkdir anotherdir
+        2:
+          path: newdir/anotherdir
+          commands:
+            - echo 'this is file2' >> file2.txt
+            - echo 'this is file3' >> file3.txt
+```
+
+Here's what will actually happen with this command.
+1. The directory `newdir` will be created
+2. A file named `file1.txt` will be created in `newdir` (`./newdir/file1.txt`)
+3. A directory named `anotherdir` will be created inside the `newdir` (`./newdir/anotherdir`)
+4. Files `file2.txt` and `file3.txt` will be created in the `anotherdir` directory (`./newdir/anotherdir`)
+
+**Example**
+
+Here is an example of a more complex `stack.yml` file with examples of different ways you can configure your commands.
+
+```yaml
+stack:
+  commands:
     test:
-      app1:
-        description: Run tests for my-app1
-        commands: cd repos/my-app1 && npm run test
-      app2:
-        description: Run tests for my-app2
-        commands: cd repos/my-app2 && npm run test
-    example:
-      this:
-        nested:
-          default:
-            description: Command runs on nested
-            commands: echo "Nested"
-          many:
-            levels:
-              run: echo "this command will run"
+      default: echo This is test default
+      zero_a: echo This is zero_a test
+    one: echo This is the most basic test
+    two:
+      - echo Test Two Command One
+      - echo Test Two Command Two
+    three:
+      description: This is test three
+      path: test
+      commands: echo Test Three Command One
+    four:
+      description: This is test four
+      commands:
+        0:
+          commands: mkdir newdir
+        1:
+          path: newdir
+          commands: mkdir anotherdir
+        2:
+          path: newdir/anotherdir
+          commands:
+            - echo 'this is file1' >> file1.txt
+            - echo 'this is file2' >> file2.txt
+    five:
+      description: This is test five
+      path: test
+      commands:
+        - echo Test Five Command One
+        - echo Test Five Command Two
+    nested:
+      default: echo Level 1
+      next:
+        default: echo Level 2
+        next:
+          default: echo Level 3
+          next:
+            default: echo Level 4
+            next:
+              default: echo Level 5
+              next: echo Level 6
 ```
 
 This `stack.yml` file will produce the following commands
 
 ```bash
-stack init
-stack up
-stack down
-stack migrate
-stack test app1
-stack test app2
-stack example this nested
-stack example this nested many levels run
+stack test
+stack one
+stack two
+stack three
+stack four
+stack five
+stack nested
+stack nested next
+stack nested next next
+stack nested next next next
+stack nested next next next next
+stack nested next next next next next
 ``` 

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+newdir/
+test/

--- a/examples/stack.yml
+++ b/examples/stack.yml
@@ -1,0 +1,43 @@
+stack:
+  commands:
+    test:
+      default: echo This is test default
+      zero_a: echo This is zero_a test
+    one: echo This is the most basic test
+    two:
+      - echo Test Two Command One
+      - echo Test Two Command Two
+    three:
+      description: This is test three
+      path: test
+      commands: echo Test Three Command One
+    four:
+      description: This is test four
+      commands:
+        0:
+          commands: mkdir newdir
+        1:
+          path: newdir
+          commands: mkdir anotherdir
+        2:
+          path: newdir/anotherdir
+          commands:
+            - echo 'this is file1' >> file1.txt
+            - echo 'this is file2' >> file2.txt
+    five:
+      description: This is test five
+      path: test
+      commands:
+        - echo Test Five Command One
+        - echo Test Five Command Two
+    nested:
+      default: echo Level 1
+      next:
+        default: echo Level 2
+        next:
+          default: echo Level 3
+          next:
+            default: echo Level 4
+            next:
+              default: echo Level 5
+              next: echo Level 6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "docker-commander",
-  "version": "1.0.0",
+  "name": "stack-commander",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/utils/Command.js
+++ b/src/utils/Command.js
@@ -1,5 +1,6 @@
 const output = require('./output')
 const shell = require('shelljs')
+const path = require('path')
 
 /**
  * Parse the commands and other values from the config
@@ -13,10 +14,12 @@ class Command
      */
     constructor(config) {
         const cfg = config.get()
+        this.basePath = cfg.basePath
         this.commands = cfg.commands || []
         this.command = cfg.command || null
         this.args = cfg.args || []
         this.description = null
+        this.path = ''
         this.exec = []
         this.errors = false
         this.parseCommands()
@@ -28,20 +31,30 @@ class Command
      * @returns array
      */
     execute() {
-
         output.headerLine(true, false)
         output.header('Executing Commands', false, false)
 
-        if (this.description) {
+        if (this.description && this.description.length > 0) {
             output.description(this.description)
         }
-        output.headerLine(true, false, '-')
 
+        output.headerLine(true, false, '-')
         output.commands(this.exec)
         output.headerLine(false, false, '-')
 
-        for (let k in this.exec) {
-            shell.exec(this.exec[k], {async: false});
+        for (let i = 0; i < this.exec.length; i++) {
+            const cmd = this.exec[i]
+
+            // Set working directory
+            let cdPath = this.basePath
+            if (cmd.path && cmd.path !== '') {
+                cdPath = path.join('/', cdPath, cmd.path)
+            }
+
+            // Execute commands
+            for (let ii = 0; ii < cmd.commands.length; ii++) {
+                shell.cd(cdPath).exec(cmd.commands[ii], {async: false});
+            }
         }
 
         output.spacer()
@@ -62,6 +75,7 @@ class Command
     parseCommands() {
         let cmd = this.commands[this.command];
 
+        // Walk down to the end of the command path
         for (let k in this.args) {
             const v = this.args[k]
             if (cmd[v]) {
@@ -76,20 +90,71 @@ class Command
         // If there are errors don't continue to process
         if (this.hasErrors()) return;
 
+        // If the top level command object has default this use it's object instead
         if (cmd.default !== undefined) {
             cmd = cmd.default
         }
 
+        // Reset exec to an empty array
+        this.exec = []
+
         if (this.getType(cmd) === 'string') {
-            this.exec = [cmd]
+            /* Example:
+                stack:
+                  commands:
+                    one: echo This is a command
+             */
+            this.addToExec('', [cmd])
         } else if (this.getType(cmd) === 'array') {
-            this.exec = cmd
+            /* Example:
+                stack:
+                  commands:
+                    one:
+                      - echo Command One
+                      - echo Command Two
+             */
+            this.addToExec('', cmd)
         } else if (this.getType(cmd.commands) === 'string') {
+            /* Example:
+                stack:
+                  commands:
+                    one:
+                      description: This is test three
+                      commands: echo Command One
+             */
             this.description = cmd.description || null
-            this.exec = [cmd.commands]
+            this.addToExec(cmd.path || '', [cmd.commands])
+        } else if (this.getType(cmd.commands) === 'object') {
+            /* Example:
+                stack:
+                  commands:
+                    one:
+                      description: This is test three
+                      commands:
+                        0:
+                          path: first_dir
+                          commands: echo Command Zero
+                        1:
+                          path: first_dir/second_dir
+                          commands:
+                            - echo Command One A
+                            - echo Command One B
+             */
+            this.description = cmd.description || null
+            this.exec = this.execFromObject(cmd.commands)
         } else if (this.getType(cmd.commands) === 'array') {
+            /* Example:
+                stack:
+                  commands:
+                    one:
+                      description: This is test three
+                      path: some_dir/other_dir
+                      commands:
+                        - echo Command One A
+                        - echo Command One B
+             */
             this.description = cmd.description || null
-            this.exec = cmd.commands
+            this.addToExec(cmd.path || '', cmd.commands)
         } else {
             output.error('The command could not be found')
             this.errors = true
@@ -97,10 +162,46 @@ class Command
     }
 
     /**
+     * Add a formatted object to the this.exec array
+     *
+     * @param path The path if any
+     * @param commands An array of commands
+     */
+    addToExec(path, commands) {
+        this.exec.push({
+            path: path,
+            commands: commands
+        })
+    }
+
+    /**
+     * Format the list of commands if commands is of type 'object'
+     *
+     * @param commands The commands object/array to format
+     *
+     * @returns array
+     */
+    execFromObject(commands) {
+        const list = []
+
+        for (let key in commands) {
+            const path = commands[key].path
+            let cmds = commands[key].commands
+            if (this.getType(cmds) === 'string') {
+                cmds = [cmds]
+            }
+            list.push({path, commands: cmds})
+        }
+
+        return list
+    }
+
+    /**
+     * Get the type of the given variable
      *
      * @param variable The variable to test
      *
-     * @returns string || array || object
+     * @returns string || undefined
      */
     getType(variable) {
         if (typeof variable === 'string') {
@@ -111,6 +212,7 @@ class Command
             return 'object'
         }
 
+        console.log('variable', variable)
         output.error('The type was unknown')
         this.error = true
 

--- a/src/utils/Config.js
+++ b/src/utils/Config.js
@@ -35,6 +35,7 @@ class Config {
 
         // Default configuration
         this.config = {
+            basePath: this.path,
             command: args.command,
             args: args.values,
             commands: cfg.stack.commands


### PR DESCRIPTION
Added the ability to set a working directory or `path` to the commands. Commands can also be in groups of commands all with separate working directories.

It is explained in more detail in the README.me file.

closes #8 