### PR TITLE
Allow adding of params

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,24 @@ stack:
 
 **With multiple commands**
 
+This will run the commands as separate commands
+
 ```yaml
 stack:
   commands:
     mydir: 
       - echo This is my current directory
       - echo $(pwd)
+```
+
+Or, if you need the commands to run as on single command you can do this:
+
+```yaml
+stack:
+  commands:
+    mydir: |
+      echo This is my current directory
+      echo $(pwd)
 ```
 
 **With a description**
@@ -72,6 +84,19 @@ stack:
       commands:
         - echo $(pwd)
         - echo There it is
+```
+
+You can make a multi line description simply by doing this:
+
+```yaml
+stack:
+  commands:
+    mydir: 
+      description: |
+        This will print out my current directory
+        This will print out on the second line of the description
+      commands:
+        - echo Command 1
 ```
 
 **With a working directory**

--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ stack:
       echo $(pwd)
 ```
 
+Or, if you have a command that will need to take in parameters you can do this:
+
+```yaml
+stack:
+  commands:
+    test:
+      filter:
+        commands: vendor/bin/phpunit --filter 
+```
+
+Then, when you run this:
+
+```bash
+stack test filter testSomeMethod testAnotherMethod
+# this will produce a filter command
+# vendor/bin/phpunit --filter testSomeMethod testAnotherMethod
+```
+
 **With a description**
 
 ```yaml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack-commander",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Add simple method for running commands on your stack",
   "main": "src/index.js",
   "scripts": {},

--- a/src/utils/Config.js
+++ b/src/utils/Config.js
@@ -66,7 +66,7 @@ class Config {
     /**
      * Get and parse the command line arguments
      *
-     * @returns {values: [], command: string}
+     * @returns {command: string, values: []}
      */
     processArgs() {
         const args = process.argv

--- a/src/utils/output.js
+++ b/src/utils/output.js
@@ -35,8 +35,16 @@ const commands = (list) => {
             spacer()
             term.green(`  | path: ${cmd.path}\n`);
         }
+
+        let params = ''
+        // Add a spacer prefix if params is not empty
+        // Also, only set params on the last command in the list
+        if (cmd.params.length > 0 && i === (list.length - 1)) {
+            params = ' ' + cmd.params
+        }
+
         for (let ii = 0; ii < cmd.commands.length; ii++) {
-            term.yellow(cleanLines(cmd.commands[ii], '  |--> '))
+            term.yellow(cleanLines(cmd.commands[ii].trim() + params, '  |--> '))
             spacer()
         }
     }


### PR DESCRIPTION
Changed so that any left over commands will be tacked on the end of the last command

This will allow you to create a command like this

```
stack:
  commands:
    test:
      commands: vendor/bin/phpunit --filter
```

````
stack test testSomeMethod
# will produce
# vendor/bin/phpunit --filter testSomeMethod
````

Also, updated the readme to reflect this behavior